### PR TITLE
Changed calendar to start on firstDayOfWeek instead of hardcoding Sunday

### DIFF
--- a/ZBJCalendar/ZBJCalendar/NSDate+IndexPath.m
+++ b/ZBJCalendar/ZBJCalendar/NSDate+IndexPath.m
@@ -33,7 +33,7 @@
     [components setMonth:indexPath.section];
     NSDate *dateToReturn = [calendar dateByAddingComponents:components toDate:[firstDate firstDateOfMonth] options:0];
     
-    if (dateToReturn < firstDay || dateToReturn > lastDate) {
+    if ([dateToReturn timeIntervalSinceNow] < [firstDay timeIntervalSinceNow] || [dateToReturn timeIntervalSinceNow] > [lastDate timeIntervalSinceNow]) {
         return nil;
     }
     return dateToReturn;

--- a/ZBJCalendar/ZBJCalendar/NSDate+IndexPath.m
+++ b/ZBJCalendar/ZBJCalendar/NSDate+IndexPath.m
@@ -21,34 +21,37 @@
 }
 
 + (NSDate *)dateAtIndexPath:(NSIndexPath *)indexPath firstDate:(NSDate *)firstDate {
+    NSCalendar *calendar = [NSDate gregorianCalendar];
     NSDate *firstDay = [NSDate  dateForFirstDayInSection:indexPath.section firstDate:firstDate];
+    NSDate * lastDate = [firstDay lastDateOfMonth];
     NSInteger weekDay = [firstDay weekday];
-    NSDate *dateToReturn = nil;
+    NSInteger weekDayStart = calendar.firstWeekday;    
+    NSInteger firstDayOffset = (weekDay < weekDayStart)? 7 : 0;
     
-    if (indexPath.row < (weekDay - 1) || indexPath.row > weekDay - 1 + [NSDate numberOfDaysInMonth:firstDay] - 1) {
-        dateToReturn = nil;
-    } else {
-        NSCalendar *calendar = [NSDate gregorianCalendar];
-        
-        NSDateComponents *components = [calendar components:NSCalendarUnitMonth | NSCalendarUnitDay fromDate:firstDay];
-        [components setDay:indexPath.row - (weekDay - 1)];
-        [components setMonth:indexPath.section];
-        dateToReturn = [calendar dateByAddingComponents:components toDate:[firstDate firstDateOfMonth] options:0];
+    NSDateComponents *components = [calendar components:NSCalendarUnitMonth | NSCalendarUnitDay fromDate:firstDay];
+    [components setDay:indexPath.row - (weekDay - weekDayStart) - firstDayOffset];
+    [components setMonth:indexPath.section];
+    NSDate *dateToReturn = [calendar dateByAddingComponents:components toDate:[firstDate firstDateOfMonth] options:0];
+    
+    if (dateToReturn < firstDay || dateToReturn > lastDate) {
+        return nil;
     }
     return dateToReturn;
 }
 
 + (NSIndexPath *)indexPathAtDate:(NSDate *)date firstDate:(NSDate *)firstDate {
     NSCalendar *calendar = [NSDate gregorianCalendar];
-    NSDateComponents *components = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:date];
     
+    NSDateComponents *components = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay fromDate:date];
     NSDateComponents *firstDateComponents = [calendar components:NSCalendarUnitYear | NSCalendarUnitMonth fromDate:firstDate];
+    NSInteger section = (components.year - firstDateComponents.year) * 12 + components.month - firstDateComponents.month;
     
     NSDate *firstDateOfMonth = [date firstDateOfMonth];
-    NSDateComponents *firstDateOfMonthComponents = [calendar components:NSCalendarUnitWeekday fromDate:firstDateOfMonth];
-    
-    NSInteger section = (components.year - firstDateComponents.year) * 12 + components.month - firstDateComponents.month;
-    NSInteger index = firstDateOfMonthComponents.weekday + components.day - 2;
+    NSInteger firstDayOffset = firstDateOfMonth.weekday - calendar.firstWeekday;
+    if (firstDayOffset < 0) {
+        firstDayOffset += 7;
+    }
+    NSInteger index = components.day + firstDayOffset - 1;
 
     return [NSIndexPath indexPathForItem:index inSection:section];
 }

--- a/ZBJCalendar/ZBJCalendar/NSDate+ZBJAddition.h
+++ b/ZBJCalendar/ZBJCalendar/NSDate+ZBJAddition.h
@@ -13,6 +13,7 @@
  */
 @interface NSDate (ZBJAddition)
 
++ (void)setGregorianCalendar:(NSCalendar *)gregorianCalendar;
 + (NSCalendar *)gregorianCalendar;
 + (NSLocale *)locale;
 

--- a/ZBJCalendar/ZBJCalendar/ZBJCalendarView.m
+++ b/ZBJCalendar/ZBJCalendar/ZBJCalendarView.m
@@ -247,12 +247,13 @@
     
     // normal logic
     NSDate *firstDay = [NSDate dateForFirstDayInSection:section firstDate:self.firstDate];
-    NSInteger weekDay = [firstDay weekday] -1;
+    NSInteger firstWeekDay = [firstDay weekday] - [NSDate gregorianCalendar].firstWeekday;
+    if (firstWeekDay < 0) {
+        firstWeekDay += 7;
+    }
     
-    NSDate *lastDateOfMonth = [firstDay lastDateOfMonth];
-    NSInteger lastWeekDay = [lastDateOfMonth weekday];
-    
-    NSInteger items =  weekDay + [NSDate numberOfDaysInMonth:firstDay] + 7 - lastWeekDay;    return items;
+    NSInteger items =  firstWeekDay + [NSDate numberOfDaysInMonth:firstDay];
+    return items;
 }
 
 - (NSInteger)numberOfSectionsInCollectionView:(UICollectionView *)collectionView {

--- a/ZBJCalendar/ZBJCalendar/ZBJCalendarWeekView.m
+++ b/ZBJCalendar/ZBJCalendar/ZBJCalendarWeekView.m
@@ -27,12 +27,12 @@
         NSArray *weekdaySymbols = nil;
         
         weekdaySymbols = [dateFormatter veryShortWeekdaySymbols];
-
+        
         NSMutableArray *adjustedSymbols = [NSMutableArray arrayWithArray:weekdaySymbols];
-        for (NSInteger index = 0; index < (1 - calendar.firstWeekday + weekdaySymbols.count + 1); index++) {
-            NSString *lastObject = [adjustedSymbols lastObject];
-            [adjustedSymbols removeLastObject];
-            [adjustedSymbols insertObject:lastObject atIndex:0];
+        for (NSInteger index = 1; index < calendar.firstWeekday; index++) {
+            NSString *firstObject = [adjustedSymbols firstObject];
+            [adjustedSymbols removeObjectAtIndex:0];
+            [adjustedSymbols addObject:firstObject];
         }
         
         self.adjustedSymbols = adjustedSymbols;


### PR DESCRIPTION
Current version of calendar starts in Sunday, and it is hardcoded. In Europe, calendars start on Monday, and actually the `firstWeekday` indicates the first day of the user's calendar. 

The current PR includes code that modifies the way the indexPaths and dates are calculated to use the calendar configuration. Besides, I have added the `+ (void)setGregorianCalendar:(NSCalendar *)gregorianCalendar;` to allow modification of this or other properties (required for Swift)